### PR TITLE
feat: probe deployment script and addresses refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@
 ## Deployments
 
 The contracts can trustlessly be deployed to their addresses on any chains that has a
-[CreateX](https://github.com/pcaversaccio/createx) deployment using the command:
+[CreateX](https://github.com/pcaversaccio/createx) deployment by following the instructions below.
+
+### Probe Deployment
+
+Before deploying the final contracts, a probe deployment is required to ensure the contracts are
+deployed to the expected addresses, and chain-specific rules (precompiles or known issues) don't
+affect the outcome.
+
+```bash
+forge script script/Deploy.s.sol:DeployProbeScript -vvv --broadcast --sender <WALLET_ADDR> --rpc-url <RPC_URL> --interactives 1
+```
+
+### Final Deployment
+
+Once the probe deployment is successful, the final deployment can be performed.
 
 ```bash
 forge script script/Deploy.s.sol:DeployScript -vvv --broadcast --sender <WALLET_ADDR> --rpc-url <RPC_URL> --interactives 1

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -2,10 +2,9 @@
 pragma solidity ^0.8.0;
 
 import {Script} from "forge-std/Script.sol";
-import {Test} from "forge-std/Test.sol";
 import {console2 as console} from "forge-std/console2.sol";
-import {HuffTest} from "../test/base/HuffTest.sol";
 import {CreationCodes} from "./utils/CreationCodes.sol";
+import {Addresses} from "src/utils/Addresses.sol";
 
 interface ICreateX {
     function deployCreate2(bytes32 salt, bytes calldata initCode) external payable returns (address);
@@ -15,7 +14,7 @@ interface ICreateX {
  * @notice Main script entrypoint. Deploys contracts with expected vanity addresses to the chain.
  * @author philogy <https://github.com/philogy>
  */
-contract DeployScript is Test, Script, HuffTest, CreationCodes {
+contract DeployScript is Script, Addresses, CreationCodes {
     ICreateX constant CREATEX = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
 
     address constant MARKET_OWNER = 0xea57c1ef7eF1c88b456ADf0927ec0EAe3B17f1F5;
@@ -66,11 +65,11 @@ contract DeployScript is Test, Script, HuffTest, CreationCodes {
 
         require(address(CREATEX).code.length > 0, "No CreateX deployed to your chain");
 
-        deployMicroCreate2({_salt: bytes32(0), _expectedAddress: MICRO_CREATE2});
+        deployMicroCreate2({_salt: bytes32(0), _expectedAddress: MICRO_CREATE2_ADDRESS});
 
-        deployNonceIncreaser({_microCreate2: MICRO_CREATE2, _expectedAddress: NONCE_INCREASER});
+        deployNonceIncreaser({_microCreate2: MICRO_CREATE2_ADDRESS, _expectedAddress: NONCE_INCREASER_ADDRESS});
 
-        deployVanityMarket({_microCreate2: MICRO_CREATE2, _expectedAddress: VANITY_MARKET});
+        deployVanityMarket({_microCreate2: MICRO_CREATE2_ADDRESS, _expectedAddress: VANITY_MARKET_ADDRESS});
 
         vm.stopBroadcast();
     }
@@ -83,20 +82,20 @@ contract DeployScript is Test, Script, HuffTest, CreationCodes {
 contract DeployProbeScript is DeployScript {
     bytes32 internal constant MICRO_CREATE2_PROBE_SALT = keccak256("safety first!");
 
-    address internal constant MICRO_CREATE2_PROBE = 0xb2EbA5Ac9d47E1F57639A115dBf7148Fab863A7E;
-    address internal constant NONCE_INCREASER_PROBE = 0x275211f908553595A0B5fA9dE5E6B1dbac52B5e2;
-    address internal constant VANITY_MARKET_PROBE = 0x3f3506b136D59CA6d0B75418559f7bA5B686f797;
+    address internal constant MICRO_CREATE2_PROBE_ADDRESS = 0xb2EbA5Ac9d47E1F57639A115dBf7148Fab863A7E;
+    address internal constant NONCE_INCREASER_PROBE_ADDRESS = 0x275211f908553595A0B5fA9dE5E6B1dbac52B5e2;
+    address internal constant VANITY_MARKET_PROBE_ADDRESS = 0x3f3506b136D59CA6d0B75418559f7bA5B686f797;
 
     function run() public virtual override {
         vm.startBroadcast();
 
         require(address(CREATEX).code.length > 0, "No CreateX deployed to your chain");
 
-        deployMicroCreate2({_salt: MICRO_CREATE2_PROBE_SALT, _expectedAddress: MICRO_CREATE2_PROBE});
+        deployMicroCreate2({_salt: MICRO_CREATE2_PROBE_SALT, _expectedAddress: MICRO_CREATE2_PROBE_ADDRESS});
 
-        deployNonceIncreaser({_microCreate2: MICRO_CREATE2_PROBE, _expectedAddress: NONCE_INCREASER_PROBE});
+        deployNonceIncreaser({_microCreate2: MICRO_CREATE2_PROBE_ADDRESS, _expectedAddress: NONCE_INCREASER_PROBE_ADDRESS});
 
-        deployVanityMarket({_microCreate2: MICRO_CREATE2_PROBE, _expectedAddress: VANITY_MARKET_PROBE});
+        deployVanityMarket({_microCreate2: MICRO_CREATE2_PROBE_ADDRESS, _expectedAddress: VANITY_MARKET_PROBE_ADDRESS});
 
         vm.stopBroadcast();
     }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import {Script} from "forge-std/Script.sol";
 import {Test} from "forge-std/Test.sol";
 import {console2 as console} from "forge-std/console2.sol";
-import {VanityMarket} from "../src/VanityMarket.sol";
 import {HuffTest} from "../test/base/HuffTest.sol";
 import {CreationCodes} from "./utils/CreationCodes.sol";
 
@@ -12,60 +11,92 @@ interface ICreateX {
     function deployCreate2(bytes32 salt, bytes calldata initCode) external payable returns (address);
 }
 
-/// @author philogy <https://github.com/philogy>
+/**
+ * @notice Main script entrypoint. Deploys contracts with expected vanity addresses to the chain.
+ * @author philogy <https://github.com/philogy>
+ */
 contract DeployScript is Test, Script, HuffTest, CreationCodes {
     ICreateX constant CREATEX = ICreateX(0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed);
 
     address constant MARKET_OWNER = 0xea57c1ef7eF1c88b456ADf0927ec0EAe3B17f1F5;
     bytes32 constant MARKET_SALT = 0x000000000000000000000000000000000000000094038e9be572f900652a472c;
 
-    function deployMicroCreate2() public {
-        address microCreate2 = CREATEX.deployCreate2(bytes32(0), MICRO_CREATE2_BYTECODE);
+    function deployMicroCreate2(bytes32 _salt, address _expectedAddress) public {
+        if (_expectedAddress.code.length != 0) {
+            console.log("MicroCreate2 already deployed");
+            return;
+        }
+
+        address microCreate2 = CREATEX.deployCreate2(_salt, MICRO_CREATE2_BYTECODE);
         console.log("MicroCreate2 deployed to: %s", microCreate2);
-        require(microCreate2 == MICRO_CREATE2, "MicroCreate2 addresses mismatch");
+        require(microCreate2 == _expectedAddress, "MicroCreate2 addresses mismatch");
     }
 
-    function deployNonceIncreaser() public {
-        (bool success, bytes memory ret) = MICRO_CREATE2.call(NONCE_INCREASER_BYTECODE);
+    function deployNonceIncreaser(address _microCreate2, address _expectedAddress) public {
+        if (_expectedAddress.code.length != 0) {
+            console.log("NonceIncreaser already deployed");
+            return;
+        }
+
+        (bool success, bytes memory ret) = _microCreate2.call(NONCE_INCREASER_BYTECODE);
         require(success && ret.length == 0x20, "NonceIncreaser deployment failed");
 
         address nonceIncreaser = abi.decode(ret, (address));
         console.log("NonceIncreaser deployed to: %s", nonceIncreaser);
-        require(nonceIncreaser == NONCE_INCREASER, "NonceIncreaser addresses mismatch");
+        require(nonceIncreaser == _expectedAddress, "NonceIncreaser addresses mismatch");
     }
 
-    function deployVanityMarket() public {
+    function deployVanityMarket(address _microCreate2, address _expectedAddress) public {
+        if (_expectedAddress.code.length != 0) {
+            console.log("VanityMarket already deployed");
+            return;
+        }
+
         bytes memory bytecode = abi.encodePacked(VANITY_MARKET_BYTECODE, abi.encode(MARKET_OWNER));
-        (bool success, bytes memory ret) = MICRO_CREATE2.call(abi.encodePacked(MARKET_SALT, bytecode));
+        (bool success, bytes memory ret) = _microCreate2.call(abi.encodePacked(MARKET_SALT, bytecode));
         require(success && ret.length == 0x20, "VanityMarket deployment failed");
 
         address vanityMarket = abi.decode(ret, (address));
         console.log("VanityMarket deployed to: %s", vanityMarket);
-        require(vanityMarket == VANITY_MARKET, "VanityMarket addresses mismatch");
+        require(vanityMarket == _expectedAddress, "VanityMarket addresses mismatch");
     }
 
-    function run() public {
+    function run() public virtual {
         vm.startBroadcast();
 
         require(address(CREATEX).code.length > 0, "No CreateX deployed to your chain");
 
-        if (address(MICRO_CREATE2).code.length == 0) {
-            deployMicroCreate2();
-        } else {
-            console.log("MicroCreate2 already deployed");
-        }
+        deployMicroCreate2({_salt: bytes32(0), _expectedAddress: MICRO_CREATE2});
 
-        if (address(NONCE_INCREASER).code.length == 0) {
-            deployNonceIncreaser();
-        } else {
-            console.log("NonceIncreaser already deployed");
-        }
+        deployNonceIncreaser({_microCreate2: MICRO_CREATE2, _expectedAddress: NONCE_INCREASER});
 
-        if (address(VANITY_MARKET).code.length == 0) {
-            deployVanityMarket();
-        } else {
-            console.log("VanityMarket already deployed");
-        }
+        deployVanityMarket({_microCreate2: MICRO_CREATE2, _expectedAddress: VANITY_MARKET});
+
+        vm.stopBroadcast();
+    }
+}
+
+/**
+ * @notice Deploy contracts with a mock salt to the chain, to act as a probe before the main script is executed.
+ * @author tinom.eth
+ */
+contract DeployProbeScript is DeployScript {
+    bytes32 internal constant MICRO_CREATE2_PROBE_SALT = keccak256("safety first!");
+
+    address internal constant MICRO_CREATE2_PROBE = 0xb2EbA5Ac9d47E1F57639A115dBf7148Fab863A7E;
+    address internal constant NONCE_INCREASER_PROBE = 0x275211f908553595A0B5fA9dE5E6B1dbac52B5e2;
+    address internal constant VANITY_MARKET_PROBE = 0x3f3506b136D59CA6d0B75418559f7bA5B686f797;
+
+    function run() public virtual override {
+        vm.startBroadcast();
+
+        require(address(CREATEX).code.length > 0, "No CreateX deployed to your chain");
+
+        deployMicroCreate2({_salt: MICRO_CREATE2_PROBE_SALT, _expectedAddress: MICRO_CREATE2_PROBE});
+
+        deployNonceIncreaser({_microCreate2: MICRO_CREATE2_PROBE, _expectedAddress: NONCE_INCREASER_PROBE});
+
+        deployVanityMarket({_microCreate2: MICRO_CREATE2_PROBE, _expectedAddress: VANITY_MARKET_PROBE});
 
         vm.stopBroadcast();
     }

--- a/src/utils/Addresses.sol
+++ b/src/utils/Addresses.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract Addresses {
+    address internal constant MICRO_CREATE2_ADDRESS = 0x6D9FB3C412a269Df566a5c92b85a8dc334F0A797;
+    address internal constant NONCE_INCREASER_ADDRESS = 0x00000000000001E4A82b33373DE1334E7d8F4879;
+    address internal constant VANITY_MARKET_ADDRESS = 0x000000000000b361194cfe6312EE3210d53C15AA;
+}

--- a/test/MicroCreate2.t.sol
+++ b/test/MicroCreate2.t.sol
@@ -16,17 +16,17 @@ contract MicroCreate2Test is Test, HuffTest {
     function test_ffi_inception() public {
         bytes memory c = _huffInitcode("src/micro-create2/MicroCreate2.huff");
         bytes32 salt = 0x736910e11ee80955bc66400158e50c2f7318633f228ac93e3edf7fe7f1341daf;
-        (bool success, bytes memory ret) = MICRO_CREATE2.call(abi.encodePacked(salt, c));
+        (bool success, bytes memory ret) = MICRO_CREATE2_ADDRESS.call(abi.encodePacked(salt, c));
         assertTrue(success);
         assertEq(ret.length, 32);
         address addr = abi.decode(ret, (address));
         assertEq(addr, _predict(salt, c));
-        assertEq(addr.code, MICRO_CREATE2.code);
+        assertEq(addr.code, MICRO_CREATE2_ADDRESS.code);
     }
 
     function test_failing() public {
         bytes32 salt = bytes32(0);
-        (bool success, bytes memory ret) = MICRO_CREATE2.call(abi.encodePacked(salt, type(FailingDeploy).creationCode));
+        (bool success, bytes memory ret) = MICRO_CREATE2_ADDRESS.call(abi.encodePacked(salt, type(FailingDeploy).creationCode));
         assertTrue(success);
         address addr = abi.decode(ret, (address));
         assertEq(addr, address(0));
@@ -37,7 +37,7 @@ contract MicroCreate2Test is Test, HuffTest {
         address dev = makeAddr("dev");
         address user = makeAddr("user");
         bytes memory initcode = abi.encodePacked(type(MockSimple).creationCode, abi.encode(dev));
-        (bool success, bytes memory ret) = MICRO_CREATE2.call(abi.encodePacked(salt, initcode));
+        (bool success, bytes memory ret) = MICRO_CREATE2_ADDRESS.call(abi.encodePacked(salt, initcode));
         assertTrue(success);
         assertEq(ret.length, 32);
         address addr = abi.decode(ret, (address));
@@ -49,7 +49,7 @@ contract MicroCreate2Test is Test, HuffTest {
     }
 
     function _predict(bytes32 salt, bytes memory initcode) internal pure returns (address) {
-        bytes32 hash = keccak256(abi.encodePacked(hex"ff", MICRO_CREATE2, salt, keccak256(initcode)));
+        bytes32 hash = keccak256(abi.encodePacked(hex"ff", MICRO_CREATE2_ADDRESS, salt, keccak256(initcode)));
         return address(uint160(uint256(hash)));
     }
 }

--- a/test/base/HuffTest.sol
+++ b/test/base/HuffTest.sol
@@ -3,27 +3,24 @@ pragma solidity ^0.8.0;
 
 import {Test} from "forge-std/Test.sol";
 import {console2 as console} from "forge-std/console2.sol";
+import {Addresses} from "src/utils/Addresses.sol";
 
 /// @author philogy <https://github.com/philogy>
-contract HuffTest is Test {
-    address internal constant MICRO_CREATE2 = 0x6D9FB3C412a269Df566a5c92b85a8dc334F0A797;
-    address internal constant NONCE_INCREASER = 0x00000000000001E4A82b33373DE1334E7d8F4879;
-    address internal constant VANITY_MARKET = 0x000000000000b361194cfe6312EE3210d53C15AA;
-
+contract HuffTest is Test, Addresses {
     function setupBase_ffi() internal {
         string[] memory empty = new string[](1);
         empty[0] = "ls";
         try vm.ffi(empty) {
-            vm.etch(MICRO_CREATE2, _huff("src/micro-create2/MicroCreate2.huff", new string[](0), false));
-            vm.etch(NONCE_INCREASER, _huff("src/deploy-proxy/NonceIncreaser.huff", new string[](0), false));
+            vm.etch(MICRO_CREATE2_ADDRESS, _huff("src/micro-create2/MicroCreate2.huff", new string[](0), false));
+            vm.etch(NONCE_INCREASER_ADDRESS, _huff("src/deploy-proxy/NonceIncreaser.huff", new string[](0), false));
         } catch {
-            if (MICRO_CREATE2.code.length != 0 && NONCE_INCREASER.code.length != 0) return;
+            if (MICRO_CREATE2_ADDRESS.code.length != 0 && NONCE_INCREASER_ADDRESS.code.length != 0) return;
             console.log(
                 "WARNING: ffi seems to be disabled and not in a fork test, reverting to hardcoded base contracts"
             );
-            vm.etch(MICRO_CREATE2, hex"60203d3581360380833d373d34f53d523df3");
+            vm.etch(MICRO_CREATE2_ADDRESS, hex"60203d3581360380833d373d34f53d523df3");
             vm.etch(
-                NONCE_INCREASER,
+                NONCE_INCREASER_ADDRESS,
                 hex"3d353d1a8060101161031357806080161561019f578060801161019f573d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df0505b806040161561026b573d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df0505b80602016156102d7573d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df0505b8060101615610313573d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df03df03df0505b7f03420372039f03c903f0041404350453046e0486049b04ad04bc04c804d104d790600f1660041b1c61ffff16565b3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3d3df03df03df03df03df03df03df0005b3d3d3d3d3d3d3d3df03df03df03df03df03df0005b3d3d3d3d3d3d3df03df03df03df03df0005b3d3d3d3d3d3df03df03df03df0005b3d3d3d3d3df03df03df0005b3d3d3d3df03df0005b3d3d3df0005b00"
             );
         }


### PR DESCRIPTION
### Description

- Add `DeployProbeScript` deployment script to deploy to a chain before running the final deployment, to solve the case for which deployment transactions simulation succeeds, but chain caveats make it fail. This is especially relevant since `MicroCreate2` call succeeds even if the deployment fails, and can leave non-standard chains in inconsistent states.
- Refactor `HuffTest` addresses to add `_ADDRESS` suffix, so that they don't conflict with `RequestMarket.VANITY_MARKET` and compilation issues are fixed. Refactor them to a common `Addresses` contract, so that `DeployScript` doesn't need to inherit `HuffTest`.